### PR TITLE
Implements a proper Google Analytics tag, and moves it to the header as

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,18 @@
 href="http://juju-solutions.github.io/rss.xml"
           title="Juju Solutions">
     <link rel="shortcut icon" href="favicon.ico">
-  </head>
+    <!-- GA -->
+    <script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-51016932-7', 'auto');
+    ga('send', 'pageview');
+
+    </script>
+    </head>
 
   <body>
 
@@ -90,19 +101,5 @@ Tools</a></li>
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="/js/jquery.js"></script>
     <script src="/js/bootstrap.min.js"></script>
-    <script type="text/javascript">
-
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '']);
-  _gaq.push(['_setDomainName', 'juju.solutions']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
-</script>
   </body>
 </html>


### PR DESCRIPTION
trackign data should be submit before the <body> render process kicks
off so we get in page analytics.

It also tracks slow load times, and other interesting bits if we include
Google webmaster toolkit - which we should add a low priority todo.

I'll be sending out access emails with this - if you need access to the
GA make sure you contact antonio, or the current team lead and they will
get you on the roster.